### PR TITLE
Quitting when ending #3

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ const WINDOW_SIZE: (f32, f32) = (1920.0, 1080.0);
 fn main() {
     let (send_to_game, receive_from_twitch) = channel::<ChatMessage>();
     let (send_to_twitch, receive_from_game) = channel::<String>();
-    let twitchchat_thread = thread::spawn(move || {
+    let _twitchchat_thread = thread::spawn(move || {
         twitch_chat_wrapper::run(receive_from_game, send_to_game).unwrap();
     });
     let game_thread = thread::spawn(move || {
@@ -30,9 +30,6 @@ fn main() {
             Err(error) => println!("Error occurred: {}", error),
         };
     });
-    match twitchchat_thread.join() {
-        Ok(_) => println!("Thanks for playing!"),
-        Err(error) => eprintln!("error that crashed the game: {:?}", error),
-    }
+
     game_thread.join().unwrap();
 }


### PR DESCRIPTION
To solve this problem I decided to just not join on the twitch wrapper thread. The join waits until that thread is done, however that thread will never be done because it runs an infinite loop. Instead of setting up some kind of commands to tell the twitch wrapper to quit, I'm just not joining on that thread anymore. Now when the game quits the main function ends which immediately ends all threads spawned by the application.

I'm not completely sure that there won't be any negative side affects, but it seems to work well with the tests that I've done.