### PR TITLE
28 Create a start splash screen to account for stream lag

### DIFF
--- a/src/draw_system/timer_draw_system.rs
+++ b/src/draw_system/timer_draw_system.rs
@@ -4,7 +4,6 @@ use ggez::nalgebra::Point2;
 use ggez::{graphics, Context, GameResult};
 
 const TIMER_WIDTH: f32 = 5.0;
-const TIMER_COLOR: Color = Color::new(1.0, 0.0, 0.0, 1.0);
 
 #[derive(Debug)]
 pub struct TimerDrawSystem {
@@ -17,12 +16,13 @@ impl TimerDrawSystem {
     pub fn new(
         (_screen_width, screen_height): (f32, f32),
         context: &mut Context,
+        (red, green, blue): (f32, f32, f32),
     ) -> GameResult<TimerDrawSystem> {
         let timer = MeshBuilder::new()
             .rectangle(
                 DrawMode::fill(),
                 Rect::new(0.0, 0.0, TIMER_WIDTH, screen_height),
-                TIMER_COLOR,
+                Color::new(red, green, blue, 1.0),
             )
             .build(context)?;
 

--- a/src/running_state.rs
+++ b/src/running_state.rs
@@ -1,5 +1,6 @@
 #[derive(Clone, Copy, PartialEq)]
 pub enum RunningState {
+    StartingSoon,
     Playing,
     PlayerWon,
     ChatWon,
@@ -8,7 +9,7 @@ pub enum RunningState {
 impl RunningState {
     pub fn is_game_over(&self) -> bool {
         match self {
-            RunningState::Playing => false,
+            RunningState::Playing | RunningState::StartingSoon => false,
             RunningState::PlayerWon | RunningState::ChatWon => true,
         }
     }

--- a/src/splash.rs
+++ b/src/splash.rs
@@ -1,0 +1,40 @@
+use std::time::{Duration, Instant};
+
+use ggez::{
+    graphics::{self, DrawParam, Font, Scale, Text},
+    nalgebra::Point2,
+    Context, GameResult,
+};
+
+pub struct Splash {
+    text: Text,
+    location: Point2<f32>,
+    finished_at: Instant,
+}
+
+impl Splash {
+    pub fn new(arena_size: (f32, f32), context: &mut Context, duration: Duration) -> Self {
+        let mut text = Text::new("Starting Soon");
+        text.set_font(Font::default(), Scale::uniform(100.0));
+        let text_size = text.dimensions(context);
+        let location = Point2::new(
+            arena_size.0 / 2.0 - text_size.0 as f32 / 2.0,
+            arena_size.1 / 2.0 - text_size.1 as f32 / 2.0,
+        );
+        let finished_at = Instant::now() + duration;
+
+        Self {
+            text,
+            location,
+            finished_at,
+        }
+    }
+
+    pub fn draw(&self, context: &mut Context) -> GameResult<()> {
+        graphics::draw(context, &self.text, DrawParam::new().dest(self.location))
+    }
+
+    pub fn is_done(&self) -> bool {
+        Instant::now() >= self.finished_at
+    }
+}


### PR DESCRIPTION
The starting soon screen lasts for 25 seconds before the game starts. There is a timer bar that is green.