### PR TITLE
FIXES 11 Add a label to drops for subscribers

### DIFF
--- a/src/chatter.rs
+++ b/src/chatter.rs
@@ -1,3 +1,5 @@
+use ggez::graphics::Color;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Chatter {
     pub name: String,
@@ -22,5 +24,9 @@ impl Chatter {
             blue,
             is_subscriber,
         }
+    }
+
+    pub fn get_color(&self) -> Color {
+        Color::from_rgba(self.red, self.green, self.blue, 255)
     }
 }

--- a/src/chatter.rs
+++ b/src/chatter.rs
@@ -4,10 +4,11 @@ pub struct Chatter {
     pub red: u8,
     pub green: u8,
     pub blue: u8,
+    pub is_subscriber: bool,
 }
 
 impl Chatter {
-    pub fn new(name: String, color: (u8, u8, u8)) -> Chatter {
+    pub fn new(name: String, color: (u8, u8, u8), is_subscriber: bool) -> Chatter {
         let (red, green, blue) = if color.0 == 0 && color.1 == 0 && color.2 == 0 {
             (100, 100, 100)
         } else {
@@ -19,6 +20,7 @@ impl Chatter {
             red,
             green,
             blue,
+            is_subscriber,
         }
     }
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,4 @@
-use ggez::{graphics::Color, nalgebra::Point2, Context, GameResult};
+use ggez::{nalgebra::Point2, Context, GameResult};
 use rand::prelude::*;
 
 use crate::{
@@ -79,10 +79,12 @@ impl Command {
     ) -> GameResult<GameObject> {
         let scale = self.get_scale();
         let sprite = self.get_sprite(context)?;
-        let label = Some((
-            self.chatter.name.clone(),
-            Color::from_rgba(self.chatter.red, self.chatter.green, self.chatter.blue, 1),
-        ));
+        let label_color = if self.chatter.is_subscriber {
+            self.chatter.get_color()
+        } else {
+            ggez::graphics::WHITE
+        };
+        let label = Some((self.chatter.name.clone(), label_color));
         let draw_system = GameObjectDrawSystem::new(Some(sprite), label, scale);
         let size = draw_system.get_size().unwrap_or((50.0, 50.0));
         let physics_system = self.get_physics();

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,4 +1,4 @@
-use ggez::{nalgebra::Point2, Context, GameResult};
+use ggez::{graphics::Color, nalgebra::Point2, Context, GameResult};
 use rand::prelude::*;
 
 use crate::{
@@ -79,7 +79,11 @@ impl Command {
     ) -> GameResult<GameObject> {
         let scale = self.get_scale();
         let sprite = self.get_sprite(context)?;
-        let draw_system = GameObjectDrawSystem::new(Some(sprite), None, scale);
+        let label = Some((
+            self.chatter.name.clone(),
+            Color::from_rgba(self.chatter.red, self.chatter.green, self.chatter.blue, 1),
+        ));
+        let draw_system = GameObjectDrawSystem::new(Some(sprite), label, scale);
         let size = draw_system.get_size().unwrap_or((50.0, 50.0));
         let physics_system = self.get_physics();
         let game_object = GameObject::new(

--- a/src/draw_system/game_object_draw_system.rs
+++ b/src/draw_system/game_object_draw_system.rs
@@ -1,5 +1,5 @@
 use super::{DrawSystem, Sprite};
-use ggez::graphics::{Color, DrawParam, Font, Scale, Text};
+use ggez::graphics::{Color, DrawParam, Font, Scale, Text, TextFragment};
 use ggez::nalgebra::Point2;
 use ggez::{graphics, Context, GameResult};
 
@@ -16,18 +16,14 @@ impl GameObjectDrawSystem {
         label: Option<(String, Color)>,
         scale_by: f32,
     ) -> GameObjectDrawSystem {
-        let label = match label {
-            Some((text, color)) => {
-                let mut text = Text::new(text);
-                text.set_font(Font::default(), Scale::uniform(35.0));
-                let fragment = &mut text.fragments_mut();
-                fragment.iter_mut().for_each(|fragment| {
-                    fragment.color(color);
-                });
-                Some(text)
-            }
-            None => None,
-        };
+        let label = label.map(|(text, color)| {
+            Text::new(
+                TextFragment::new(text)
+                    .font(Font::default())
+                    .scale(Scale::uniform(35.0))
+                    .color(color),
+            )
+        });
         GameObjectDrawSystem {
             sprite,
             label,

--- a/src/draw_system/game_object_draw_system.rs
+++ b/src/draw_system/game_object_draw_system.rs
@@ -1,5 +1,5 @@
 use super::{DrawSystem, Sprite};
-use ggez::graphics::{DrawParam, Font, Scale, Text};
+use ggez::graphics::{Color, DrawParam, Font, Scale, Text};
 use ggez::nalgebra::Point2;
 use ggez::{graphics, Context, GameResult};
 
@@ -13,13 +13,17 @@ pub struct GameObjectDrawSystem {
 impl GameObjectDrawSystem {
     pub fn new(
         sprite: Option<Sprite>,
-        label: Option<String>,
+        label: Option<(String, Color)>,
         scale_by: f32,
     ) -> GameObjectDrawSystem {
         let label = match label {
-            Some(text) => {
+            Some((text, color)) => {
                 let mut text = Text::new(text);
                 text.set_font(Font::default(), Scale::uniform(35.0));
+                let fragment = &mut text.fragments_mut();
+                fragment.iter_mut().for_each(|fragment| {
+                    fragment.color(color);
+                });
                 Some(text)
             }
             None => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,11 @@ impl EventHandler for GameState {
                         };
                         match Command::new(
                             &chat_message.message,
-                            Chatter::new(chatter_name, chat_message.color_rgb),
+                            Chatter::new(
+                                chatter_name,
+                                chat_message.color_rgb,
+                                chat_message.subscriber,
+                            ),
                         ) {
                             Err(error) => self.send_to_chat.send(error.to_owned()).unwrap(),
                             Ok(command) => self.handle_command(command, context)?,

--- a/src/physics/player_physics.rs
+++ b/src/physics/player_physics.rs
@@ -99,7 +99,7 @@ impl PhysicsSystem for PlayerPhysics {
                         let chatter = if let Some(chatter) = game_object.chatter {
                             chatter
                         } else {
-                            Chatter::new(DEFAULT_CHATTER_NAME.to_owned(), (255, 255, 255))
+                            Chatter::new(DEFAULT_CHATTER_NAME.to_owned(), (255, 255, 255), false)
                         };
                         self.player_hit_object.send(chatter)?;
                     }


### PR DESCRIPTION
drops now get labels of the chatter who dropped them.

The labels are white by default. If the chatter is a subscriber then their label will be the color that they set in Twitch.