### PR TITLE
allow for standard qwerty controls too

### DIFF
--- a/src/physics/player_physics.rs
+++ b/src/physics/player_physics.rs
@@ -32,7 +32,8 @@ impl PlayerPhysics {
     fn handle_input(&mut self, context: &mut Context) {
         if input::keyboard::is_key_pressed(context, KeyCode::A) {
             self.velocity.x -= MOVE_FORCE;
-        } else if input::keyboard::is_key_pressed(context, KeyCode::S) {
+        } else if input::keyboard::is_key_pressed(context, KeyCode::S)
+            || input::keyboard::is_key_pressed(context, KeyCode::D) {
             self.velocity.x += MOVE_FORCE;
         }
 


### PR DESCRIPTION
`a` is left
`s` and `d` are right