### PR TITLE
48 Increase number of iframes when streamer is hit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,6 @@ impl GameState {
             let high_score = high_scores.entry(username.to_owned()).or_insert(0);
             *high_score += *score;
         }
-        dbg!("updating scores");
     }
 }
 impl EventHandler for GameState {

--- a/src/life_system/player_life_system.rs
+++ b/src/life_system/player_life_system.rs
@@ -24,6 +24,22 @@ impl PlayerLifeSystem {
             frame_count: IFRAMES_REDUCE_EVERY,
         }
     }
+
+    fn update_iframes(&mut self) {
+        if self.iframes > IFRAMES_MIN {
+            self.frame_count -= 1;
+            if self.frame_count == 0 {
+                self.frame_count = IFRAMES_REDUCE_EVERY;
+                self.iframes -= IFRAMES_REDUCE_BY;
+            }
+        }
+    }
+
+    fn update_iframes_left(&mut self) {
+        if self.iframes_left > 0 {
+            self.iframes_left -= 1;
+        }
+    }
 }
 
 impl LifeSystem for PlayerLifeSystem {
@@ -42,17 +58,8 @@ impl LifeSystem for PlayerLifeSystem {
     }
 
     fn update(&mut self, _screen_size: (f32, f32), _location: &Rect) {
-        if self.iframes > IFRAMES_MIN {
-            self.frame_count -= 1;
-            if self.frame_count == 0 {
-                self.frame_count = IFRAMES_REDUCE_EVERY;
-                self.iframes -= IFRAMES_REDUCE_BY;
-            }
-        }
-
-        if self.iframes_left > 0 {
-            self.iframes_left -= 1;
-        }
+        self.update_iframes();
+        self.update_iframes_left();
     }
 
     fn gain_life(&mut self) {

--- a/src/life_system/player_life_system.rs
+++ b/src/life_system/player_life_system.rs
@@ -2,10 +2,17 @@ use ggez::graphics::Rect;
 
 use super::LifeSystem;
 
+const IFRAMES_REDUCE_EVERY: u32 = 720;
+const IFRAMES_REDUCE_BY: u8 = 10;
+const IFRAMES_MIN: u8 = 10;
+const IFRAMES_START: u8 = 120;
+
 #[derive(Debug)]
 pub struct PlayerLifeSystem {
     lives: u8,
     iframes_left: u8,
+    iframes: u8,
+    frame_count: u32,
 }
 
 impl PlayerLifeSystem {
@@ -13,6 +20,8 @@ impl PlayerLifeSystem {
         PlayerLifeSystem {
             lives: 3,
             iframes_left: 0,
+            iframes: IFRAMES_START,
+            frame_count: IFRAMES_REDUCE_EVERY,
         }
     }
 }
@@ -25,7 +34,7 @@ impl LifeSystem for PlayerLifeSystem {
     fn hit(&mut self) -> bool {
         if self.iframes_left == 0 {
             self.lives -= 1;
-            self.iframes_left = 12;
+            self.iframes_left = self.iframes;
             true
         } else {
             false
@@ -33,6 +42,14 @@ impl LifeSystem for PlayerLifeSystem {
     }
 
     fn update(&mut self, _screen_size: (f32, f32), _location: &Rect) {
+        if self.iframes > IFRAMES_MIN {
+            self.frame_count -= 1;
+            if self.frame_count == 0 {
+                self.frame_count = IFRAMES_REDUCE_EVERY;
+                self.iframes -= IFRAMES_REDUCE_BY;
+            }
+        }
+
         if self.iframes_left > 0 {
             self.iframes_left -= 1;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,6 @@ fn main() {
         &mut GameState::new(send_to_twitch, receive_from_twitch, WINDOW_SIZE, context).unwrap();
     match event::run(context, event_loop, game_state) {
         Ok(_) => println!("Thanks for playing!"),
-        Err(error) => println!("Error occurred: {}", error),
+        Err(error) => eprintln!("Error occurred: {}", error),
     };
 }


### PR DESCRIPTION
We start with 120 iframes, then 10 times throughout the game those iframes get reduced until they hit the minimum, which is 10. This should make the game easier to play at the beginning, and hopefully make all of the games last longer.